### PR TITLE
Fixes for older Python and better errors where things are unsupported

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "ducktools-pythonfinder>=0.7.6",
     "textual>=1.0",
     "shellingham~=1.5",
-    "pip>=24.0",
+    "pip~=25.0",
 ]
 classifiers = [
     "Development Status :: 1 - Planning",


### PR DESCRIPTION
Politely error saying something is unsupported instead of crashing for things that don't work on old python/micropython.

Make the venv creation logic work on Python not supported by pip, but keep updating pip on 3.9 or later.

Be stricter about pip version, I'll need to modify the code for 3.9 before pip 26.0, bump the version then.