### PR TITLE
Add basic configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,21 +17,36 @@ Run with `pytui` or `ducktools-pytui`.
 ## Features ##
 
 * List Python Virtual Environments relative to the current folder
-* List Python Runtimes
+* List Python Runtimes discovered by [ducktools-pythonfinder](https://github.com/DavidCEllis/ducktools-pythonfinder)
 * Launch a Terminal with a selected venv activated
   * Currently only 'tested' with bash, zsh (on macos), powershell and cmd.
-  * It's possible shell config files may break the environment variable changes. 
+  * It's possible shell config files may break the environment variable changes.
 * Launch a REPL with the selected venv
 * Launch a REPL with the selected runtime
-* List installed packages in a venv
-* Create a venv from a specific runtime
+* List installed packages in a venv (Python 3.9 or later)
+* Create a venv from a specific runtime (Python 3.4 or later)
 * Delete a selected venv
+
+### Basic Configuration ###
+
+Some configuration is available by editing the config.json file located here:
+
+* Windows: `%LOCALAPPDATA%\ducktools\pytui\config.json`
+* Linux/Mac/Other: `~/.ducktools/pytui/config.json`
+
+### Config Values ###
+* `venv_search_mode` - Where to search for VEnv folders
+  * `"cwd"` - Search in the working directory only
+  * `"parents"` - Search in the working directory and each parent folder (default)
+  * `"recursive"` - Search in the working directory and subfolders recursively
+  * `"recursive_parents"` - Combine the "recursive" and "parents" options (only the CWD is recursively searched)
+* `fast_runtime_search` - Skip any potential Python runtimes that will require querying the interpreter (default: `False`)
+  * This may make the start time faster in some cases, but will miss runtimes on PATH or alternate interpreters
+* `include_pip` - Whether to include `pip` (and `setuptools` where appropriate) in created VEnvs (default: `True`)
+* `latest_pip` - Download the latest `pip` for Python versions where it is available (default: `True`)
 
 ### Planned ###
 
-* Config file with some saved settings
-  * Option: Create venv without pip or without the latest pip
-  * Keep the theme the user selected
 * Allow selecting 'default' packages to install, auto-editable install option with extras
 * Add commands to install/uninstall runtimes of tools with runtime managers (eg: UV, pyenv)
 * Highlight invalid venvs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ authors = [
 readme="README.md"
 requires-python = ">=3.10.0"
 dependencies = [
-    "ducktools-pythonfinder>=0.7.6",
+    "ducktools-classbuilder>=0.7.5",
+    "ducktools-pythonfinder>=0.7.8",
     "textual>=1.0",
     "shellingham~=1.5",
     "pip~=25.0",

--- a/src/ducktools/pytui/commands.py
+++ b/src/ducktools/pytui/commands.py
@@ -68,7 +68,11 @@ def create_venv(
     # These tasks run in the background so don't need to block ctrl+c
     # Capture output to not mess with the textual display
     # 3.8 support is going in the next pip update
-    if include_pip and (not latest_pip or python_runtime.version < (3, 9)):
+    # Also always include the pip bundled with graalpy and don't update
+    if (
+        include_pip and (not latest_pip or python_runtime.version < (3, 9))
+        or python_runtime.implementation == "graalpy"
+    ):
         subprocess.run(
             [python_exe, "-m", "venv", venv_path],
             capture_output=True,

--- a/src/ducktools/pytui/config.py
+++ b/src/ducktools/pytui/config.py
@@ -1,0 +1,104 @@
+# This file is a part of ducktools.pytui
+# A TUI for managing Python installs and virtual environments
+#
+# Copyright (C) 2025  David C Ellis
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import os
+import os.path
+import json
+import sys
+from typing import ClassVar
+
+from ducktools.classbuilder.prefab import Prefab, as_dict, attribute
+
+
+# Code to work out where to store data
+# Store in LOCALAPPDATA for windows, User folder for other operating systems
+if sys.platform == "win32":
+    # os.path.expandvars will actually import a whole bunch of other modules
+    # Try just using the environment.
+    if _local_app_folder := os.environ.get("LOCALAPPDATA"):
+        if not os.path.isdir(_local_app_folder):
+            raise FileNotFoundError(
+                f"Could not find local app data folder {_local_app_folder}"
+            )
+    else:
+        raise EnvironmentError(
+            "Environment variable %LOCALAPPDATA% "
+            "for local application data folder location "
+            "not found"
+        )
+    USER_FOLDER = _local_app_folder
+    PYTUI_FOLDER = os.path.join(USER_FOLDER, "ducktools", "pytui")
+else:
+    USER_FOLDER = os.path.expanduser("~")
+    PYTUI_FOLDER = os.path.join(USER_FOLDER, ".ducktools", "pytui")
+
+CONFIG_FILE = os.path.join(PYTUI_FOLDER, "config.json")
+
+
+class Config(Prefab):
+    VENV_SEARCH_MODES: ClassVar[set[str]] = {
+        "cwd", "parents", "recursive", "recursive_parents"
+    }
+    config_file: str = attribute(default=CONFIG_FILE, serialize=False)
+    venv_search_mode: str = "parents"
+    fast_runtime_search: bool = False
+    include_pip: bool = True
+    latest_pip: bool = True
+
+    def write_config(self):
+        os.makedirs(os.path.dirname(self.config_file), exist_ok=True)
+        with open(self.config_file, 'w') as f:
+            json.dump(as_dict(self), f, indent=4)
+
+    @classmethod
+    def from_file(cls, config_file=CONFIG_FILE):
+        if os.path.exists(config_file):
+            with open(config_file, 'r') as f:
+                try:
+                    raw_input = json.load(f)
+                except json.JSONDecodeError:
+                    raw_input = {}
+
+            venv_search_mode = raw_input.get("venv_search_mode", "parents")
+            fast_runtime_search = raw_input.get("fast_runtime_search", False)
+            include_pip = raw_input.get("include_pip", True)
+            latest_pip = raw_input.get("latest_pip", True)
+
+            if venv_search_mode not in cls.VENV_SEARCH_MODES:
+                venv_search_mode = "parents"
+            if not isinstance(fast_runtime_search, bool):
+                fast_runtime_search = False
+            if not isinstance(include_pip, bool):
+                include_pip = True
+            if not isinstance(latest_pip, bool):
+                latest_pip = True
+
+            config = cls(
+                config_file=config_file,
+                venv_search_mode=venv_search_mode,
+                fast_runtime_search=fast_runtime_search,
+                include_pip=include_pip,
+                latest_pip=latest_pip,
+            )
+
+            if raw_input != as_dict(config):
+                config.write_config()
+
+        else:
+            config = cls(config_file=config_file)
+            config.write_config()
+        return config

--- a/src/ducktools/pytui/ui.py
+++ b/src/ducktools/pytui/ui.py
@@ -284,7 +284,7 @@ class ManagerApp(App):
         self._venv_dependency_cache: dict[str, list[PythonPackage]] = {}
 
     def on_mount(self):
-        self.title = "Ducktools.PyTui: Python Environment and Runtime Manager"
+        self.title = "Ducktools.PyTUI: Python Environment and Runtime Manager"
 
     def compose(self):
         yield Header()

--- a/src/ducktools/pytui/ui.py
+++ b/src/ducktools/pytui/ui.py
@@ -191,12 +191,16 @@ class VEnvTable(DataTable):
             if clear_first:
                 self.clear(columns=False)
                 self._venv_catalogue = {}
+
+            recursive = "recursive" in self.config.venv_search_mode
+            search_parent_folders = "parents" in self.config.venv_search_mode
             for venv in get_python_venvs(
                 base_dir=CWD,
-                recursive=False,
-                search_parent_folders=True
+                recursive=recursive,
+                search_parent_folders=search_parent_folders,
             ):
                 self.add_venv(venv, sort=False)
+
         finally:
             self.sort_by_path()
             self.loading = False

--- a/src/ducktools/pytui/util/__init__.py
+++ b/src/ducktools/pytui/util/__init__.py
@@ -24,7 +24,13 @@ import subprocess
 from ducktools.pythonfinder import list_python_installs, PythonInstall
 
 
-def list_installs_deduped(query_executables: bool = True) -> list[PythonInstall]:
+def list_installs_deduped(*, query_executables: bool = True) -> list[PythonInstall]:
+    """
+    Get a list of Python executables, but try to avoid multiple aliases to the same Python runtime.
+
+    :param query_executables: Query executables discovered
+    :return: List of PythonInstall instances
+    """
     installs = list_python_installs(query_executables=query_executables)
 
     # First sort so the executables are in priority order


### PR DESCRIPTION
This adds a config class which includes settings for:
Skipping runtimes that need querying, creating venvs without pip (or without the latest pip), searching for venvs in subfolders.