### PR TITLE
Need rcs in order to get the complete zsh default prompt.

### DIFF
--- a/src/ducktools/pytui/commands.py
+++ b/src/ducktools/pytui/commands.py
@@ -193,7 +193,7 @@ def launch_shell(venv: PythonVEnv) -> None:
     elif shell_name == "zsh":
         # Try to get the shell PS1 from subprocess
         prompt_getter = subprocess.run(
-            ["zsh", "-ic", "--no-rcs", "echo $PS1"], 
+            ["zsh", "-ic", "echo $PS1"], 
             text=True, 
             capture_output=True
         )


### PR DESCRIPTION
I noticed the folder was missing from the zsh prompt on MacOS if no venv was previously activated. Adding the rcs should get the prompt detail the user expects.