### PR TITLE
Move linux config to a more standard folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Run with `pytui` or `ducktools-pytui`.
 Some configuration is available by editing the config.json file located here:
 
 * Windows: `%LOCALAPPDATA%\ducktools\pytui\config.json`
-* Linux/Mac/Other: `~/.ducktools/pytui/config.json`
+* Linux/Mac/Other: `~/.config/ducktools/pytui/config.json`
 
 ### Config Values ###
 * `venv_search_mode` - Where to search for VEnv folders

--- a/src/ducktools/pytui/config.py
+++ b/src/ducktools/pytui/config.py
@@ -44,7 +44,22 @@ if sys.platform == "win32":
     PYTUI_FOLDER = os.path.join(USER_FOLDER, "ducktools", "pytui")
 else:
     USER_FOLDER = os.path.expanduser("~")
-    PYTUI_FOLDER = os.path.join(USER_FOLDER, ".ducktools", "pytui")
+
+    # Versions prior to 0.2.0 used this old folder
+    OLD_FOLDER = os.path.join(USER_FOLDER, ".ducktools", "pytui")
+    PYTUI_FOLDER = os.path.join(USER_FOLDER, ".config", "ducktools", "pytui")
+
+    # If you used a version prior to v0.2.0
+    if os.path.exists(OLD_FOLDER):
+        import shutil
+
+        # Delete the old folder if the new one already exists, move otherwise
+        if os.path.exists(PYTUI_FOLDER):
+            shutil.rmtree(OLD_FOLDER)
+        else:
+            os.makedirs(os.path.dirname(PYTUI_FOLDER), exist_ok=True)
+            shutil.move(OLD_FOLDER, PYTUI_FOLDER)
+
 
 CONFIG_FILE = os.path.join(PYTUI_FOLDER, "config.json")
 

--- a/src/ducktools/pytui/config.py
+++ b/src/ducktools/pytui/config.py
@@ -45,11 +45,11 @@ if sys.platform == "win32":
 else:
     USER_FOLDER = os.path.expanduser("~")
 
-    # Versions prior to 0.2.0 used this old folder
+    # Versions prior to 0.1.3 used this old folder
     OLD_FOLDER = os.path.join(USER_FOLDER, ".ducktools", "pytui")
     PYTUI_FOLDER = os.path.join(USER_FOLDER, ".config", "ducktools", "pytui")
 
-    # If you used a version prior to v0.2.0
+    # If you used a version prior to v0.1.3
     if os.path.exists(OLD_FOLDER):
         import shutil
 

--- a/tests/test_folder.py
+++ b/tests/test_folder.py
@@ -1,0 +1,29 @@
+# This file is a part of ducktools.pytui
+# A TUI for managing Python installs and virtual environments
+#
+# Copyright (C) 2025  David C Ellis
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import os
+import os.path
+import sys
+
+from ducktools.pytui import config
+
+def test_folder():
+    if sys.platform == "win32":
+        base = os.environ.get("LOCALAPPDATA")
+        assert config.CONFIG_FILE == os.path.join(base, "ducktools", "pytui", "config.json")
+    else:
+        assert config.CONFIG_FILE == os.path.expanduser("~/.config/ducktools/pytui/config.json")


### PR DESCRIPTION
This moves the config file from `~/.ducktools/pytui/config.json` to `~/.config/ducktools/pytui/config.json`.