### PR TITLE
Update the pythonfinder requirement due to a bug in v0.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ readme="README.md"
 requires-python = ">=3.10.0"
 dependencies = [
     "ducktools-classbuilder>=0.7.5",
-    "ducktools-pythonfinder>=0.7.8",
+    "ducktools-pythonfinder>=0.8.1",
     "textual>=1.0",
     "shellingham~=1.5",
     "pip~=25.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,9 +10,9 @@ ducktools-lazyimporter==0.7.2 \
     --hash=sha256:6d6fe2690200e0f03c7898410ba459e64de3a554ba7a0e7396a333da98e8e5fa \
     --hash=sha256:6f5ae8c965efe2011331449b94e5dace778c08783f643c2db30bc316826529da
     # via ducktools-pythonfinder
-ducktools-pythonfinder==0.8.0 \
-    --hash=sha256:5c72903da6a9e7c7366a2d9af346a27fd391412501f24f2ca0c75304b55e0354 \
-    --hash=sha256:f193975e2cde65c5f7b9d207c23f80d6ec7fbe035ec7ca784771b1194889ae74
+ducktools-pythonfinder==0.8.1 \
+    --hash=sha256:3d8969e814258e12542e3f53d9e5491d21223b4a153f38dccceecddedc007621 \
+    --hash=sha256:aa3a60887b6e5b30204e6c3938a815e2357d3e4dc31e0717fb58f8a04a8a3e02
     # via ducktools-pytui (pyproject.toml)
 linkify-it-py==2.0.3 \
     --hash=sha256:68cda27e162e9215c17d786649d1da0021a451bdc436ef9e0fa0ba5234b9b048 \


### PR DESCRIPTION
v0.8.0 of pythonfinder accidentally added a type hint to the details script along with an f-string which meant it could no longer find Python versions that didn't have these features.