### PR TITLE
Fix for when using latest ducktools-pythonfinder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ readme="README.md"
 requires-python = ">=3.10.0"
 dependencies = [
     "ducktools-classbuilder>=0.7.5",
-    "ducktools-pythonfinder>=0.8.1",
+    "ducktools-pythonfinder>=0.8.2",
     "textual>=1.0",
     "shellingham~=1.5",
     "pip~=25.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,9 +10,9 @@ ducktools-lazyimporter==0.7.2 \
     --hash=sha256:6d6fe2690200e0f03c7898410ba459e64de3a554ba7a0e7396a333da98e8e5fa \
     --hash=sha256:6f5ae8c965efe2011331449b94e5dace778c08783f643c2db30bc316826529da
     # via ducktools-pythonfinder
-ducktools-pythonfinder==0.8.1 \
-    --hash=sha256:3d8969e814258e12542e3f53d9e5491d21223b4a153f38dccceecddedc007621 \
-    --hash=sha256:aa3a60887b6e5b30204e6c3938a815e2357d3e4dc31e0717fb58f8a04a8a3e02
+ducktools-pythonfinder==0.8.2 \
+    --hash=sha256:27b88bd87c8a839cc42c61254a709afd5b1f537855bb0a9486dfee4fcb4037e6 \
+    --hash=sha256:7fb386e21aaf832b15098e6e7f52c4312b2a759d6fc609587e1a6a9bd7013bee
     # via ducktools-pytui (pyproject.toml)
 linkify-it-py==2.0.3 \
     --hash=sha256:68cda27e162e9215c17d786649d1da0021a451bdc436ef9e0fa0ba5234b9b048 \

--- a/src/ducktools/pytui/config.py
+++ b/src/ducktools/pytui/config.py
@@ -76,7 +76,6 @@ class Config(Prefab):
     }
     config_file: str = attribute(default=CONFIG_FILE, serialize=False)
     venv_search_mode: str = "parents"
-    fast_runtime_search: bool = False
     include_pip: bool = True
     latest_pip: bool = True
 
@@ -95,14 +94,11 @@ class Config(Prefab):
                     raw_input = {}
 
             venv_search_mode = raw_input.get("venv_search_mode", "parents")
-            fast_runtime_search = raw_input.get("fast_runtime_search", False)
             include_pip = raw_input.get("include_pip", True)
             latest_pip = raw_input.get("latest_pip", True)
 
             if venv_search_mode not in cls.VENV_SEARCH_MODES:
                 venv_search_mode = "parents"
-            if not isinstance(fast_runtime_search, bool):
-                fast_runtime_search = False
             if not isinstance(include_pip, bool):
                 include_pip = True
             if not isinstance(latest_pip, bool):
@@ -111,7 +107,6 @@ class Config(Prefab):
             config = cls(
                 config_file=config_file,
                 venv_search_mode=venv_search_mode,
-                fast_runtime_search=fast_runtime_search,
                 include_pip=include_pip,
                 latest_pip=latest_pip,
             )

--- a/src/ducktools/pytui/ui.py
+++ b/src/ducktools/pytui/ui.py
@@ -318,8 +318,7 @@ class RuntimeTable(DataTable):
                 self.clear()
                 self._runtime_catalogue = {}
 
-            query_executables = not self.config.fast_runtime_search
-            for install in list_installs_deduped(query_executables=query_executables):
+            for install in list_installs_deduped():
                 self._runtime_catalogue[install.executable] = install
 
                 if install.version_str == install.implementation_version_str:

--- a/src/ducktools/pytui/util/__init__.py
+++ b/src/ducktools/pytui/util/__init__.py
@@ -29,14 +29,13 @@ import subprocess
 from ducktools.pythonfinder import list_python_installs, PythonInstall
 
 
-def list_installs_deduped(*, query_executables: bool = True) -> list[PythonInstall]:
+def list_installs_deduped() -> list[PythonInstall]:
     """
     Get a list of Python executables, but try to avoid multiple aliases to the same Python runtime.
 
-    :param query_executables: Query executables discovered
     :return: List of PythonInstall instances
     """
-    installs = list_python_installs(query_executables=query_executables)
+    installs = list_python_installs()
 
     # First sort so the executables are in priority order
     deduped_installs = []


### PR DESCRIPTION
The query_executables argument was removed in the latest ducktools-pythonfinder which causes ducktools-pytui to fail to start. This removes the usage of that argument.