### PR TITLE
Fix shell check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "ducktools-classbuilder>=0.8.3",
     "ducktools-pythonfinder>=0.8.6",
     "ducktools-lazyimporter>=0.7.3",
-    "textual>=3.0",
+    "textual>=3.2.0",
     "shellingham~=1.5",
 ]
 classifiers = [

--- a/src/ducktools/pytui/commands.py
+++ b/src/ducktools/pytui/commands.py
@@ -193,8 +193,8 @@ def get_shell():
 
                 if guid and profiles:
                     for p in profiles:
-                        if p["guid"] == guid:
-                            shell = os.path.expandvars(p["commandline"])
+                        if p["guid"] == guid and (commandline := p.get("commandline")):
+                            shell = os.path.expandvars(commandline)
                             shell_name = os.path.splitext(os.path.basename(shell))[0]
                             break
 
@@ -206,7 +206,7 @@ def get_shell():
             try:
                 shell = os.environ["SHELL"]
             except KeyError:
-                raise RuntimeError(f"Shell detection failed")
+                raise RuntimeError("Shell detection failed")
             else:
                 shell_name = os.path.basename(shell)
 


### PR DESCRIPTION
Some shell options in the windows terminal don't have a commandline option - if this is the case these are ignored and the fallback to cmd is used.