### PR TITLE
Better deduplication logic for python binaries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ readme="README.md"
 requires-python = ">=3.8.0"
 dependencies = [
     "ducktools-classbuilder>=0.9.0",
-    "ducktools-pythonfinder>=0.8.6",
+    "ducktools-pythonfinder>=0.9.0",
     "ducktools-lazyimporter>=0.7.3",
     "textual>=3.2.0",
     "importlib_resources>=6.4",  # restricted in constraints for Python 3.8 support

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,9 +12,9 @@ ducktools-lazyimporter==0.7.3 \
     # via
     #   ducktools-pytui (pyproject.toml)
     #   ducktools-pythonfinder
-ducktools-pythonfinder==0.8.6 \
-    --hash=sha256:8f593dba82f2a45341f9b1db2aa26d2aeb8ad91ddb7d9d3647040ac78495264b \
-    --hash=sha256:9dcb218fac1f8130d0b94f4ff39f15d8e49c23a82922a2909c7c2c475398595a
+ducktools-pythonfinder==0.9.0 \
+    --hash=sha256:940009666d234429177b7689bcd80db973d29a09a020bbf793f2c5e7dbdc79b5 \
+    --hash=sha256:cbb15b3b4af3b163377424ce0b5c7ba5e09f844e7c959ac7a328f3fdbd030036
     # via ducktools-pytui (pyproject.toml)
 importlib-resources==6.4.5 \
     --hash=sha256:980862a1d16c9e147a59603677fa2aa5fd82b87f223b6cb870695bcfce830065 \

--- a/src/ducktools/pytui/util/__init__.py
+++ b/src/ducktools/pytui/util/__init__.py
@@ -40,13 +40,14 @@ def list_installs_deduped() -> list[PythonInstall]:
 
     # First sort so the executables are in priority order
     deduped_installs = []
-    used_folders = set()
+    used_stdlib_folders = set()
     for inst in installs:
-        fld = os.path.dirname(inst.executable)
-        if fld in used_folders:
-            continue
-
-        used_folders.add(fld)
+        fld = inst.paths.get("stdlib")
+        if fld:
+            if fld in used_stdlib_folders:
+                continue
+            used_stdlib_folders.add(fld)
+    
         deduped_installs.append(inst)
 
     return deduped_installs


### PR DESCRIPTION
This should mean that all binaries in `/usr/bin` are found including those for different python versions, but installs that share the same stdlib are ignored.