### PR TITLE
Better disconnected errors - list uv installs as "Astral uv"

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ Some example commands:
 * `global_venv_folder` - The folder to use for global pytui venvs, `~/.local/share/ducktools/pytui/venvs` by default
 * `shell_path` - Path to the shell used to launch activated venvs
 
+### Clearing the discovered Python install cache ###
+
+The Python install discovery cache is handled by the 
+[ducktools-pythonfinder](https://github.com/DavidCEllis/ducktools-pythonfinder)
+ package.
+
+The easiest way to clear the cache is to use the `ducktools-pythonfinder` commandline.
+
+* With uv: `uvx ducktools-pythonfinder clear-cache`
+* With pipx: `pipx run ducktools-pythonfinder clear-cache`
+* With the [pythonfinder zipapp](https://github.com/DavidCEllis/ducktools-pythonfinder/releases/latest): `python pythonfinder.pyz clear-cache`
+
 ### Shell Discovery ###
 
 By default PyTUI will check your `$SHELL` variable if it is set for the path to your default shell.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ readme="README.md"
 requires-python = ">=3.8.0"
 dependencies = [
     "ducktools-classbuilder>=0.9.0",
-    "ducktools-pythonfinder>=0.9.0",
+    "ducktools-pythonfinder>=0.9.1",
     "ducktools-lazyimporter>=0.7.3",
     "textual>=3.2.0",
     "importlib_resources>=6.4",  # restricted in constraints for Python 3.8 support

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,9 +12,9 @@ ducktools-lazyimporter==0.7.3 \
     # via
     #   ducktools-pytui (pyproject.toml)
     #   ducktools-pythonfinder
-ducktools-pythonfinder==0.9.0 \
-    --hash=sha256:940009666d234429177b7689bcd80db973d29a09a020bbf793f2c5e7dbdc79b5 \
-    --hash=sha256:cbb15b3b4af3b163377424ce0b5c7ba5e09f844e7c959ac7a328f3fdbd030036
+ducktools-pythonfinder==0.9.1 \
+    --hash=sha256:cde5d7c1b4f7625a4284e072891936b8bb174fe1a214415122c93f5b697001d8 \
+    --hash=sha256:ece0f35f06fcfe42d7ae22f6b8a539a050218374f0571eef65352c02c7283def
     # via ducktools-pytui (pyproject.toml)
 importlib-resources==6.4.5 \
     --hash=sha256:980862a1d16c9e147a59603677fa2aa5fd82b87f223b6cb870695bcfce830065 \

--- a/src/ducktools/pytui/runtime_installers/pythoncore.py
+++ b/src/ducktools/pytui/runtime_installers/pythoncore.py
@@ -186,7 +186,7 @@ class PythonCoreListing(PythonListing):
         ]
 
         result = subprocess.run(
-            cmd, capture_output=True, text=True, check=True
+            cmd, capture_output=True, text=True
         )
         return result
 
@@ -205,6 +205,6 @@ class PythonCoreListing(PythonListing):
             self.manager.executable, "uninstall", tag, "-y",
         ]
         result = subprocess.run(
-            cmd, capture_output=True, text=True, check=True
+            cmd, capture_output=True, text=True
         )
         return result

--- a/src/ducktools/pytui/runtime_installers/uv.py
+++ b/src/ducktools/pytui/runtime_installers/uv.py
@@ -175,7 +175,6 @@ class UVPythonListing(PythonListing):
             cmd,
             capture_output=True,
             text=True,
-            check=True,
         )
         return result
 
@@ -194,6 +193,5 @@ class UVPythonListing(PythonListing):
             cmd,
             capture_output=True,
             text=True,
-            check=True,
         )
         return result

--- a/src/ducktools/pytui/runtime_installers/uv.py
+++ b/src/ducktools/pytui/runtime_installers/uv.py
@@ -37,7 +37,7 @@ from .base import RuntimeManager, PythonListing
 
 
 class UVManager(RuntimeManager):
-    organisation: ClassVar[str] = "Astral"
+    organisation: ClassVar[str] = "Astral uv"
 
     @functools.cached_property
     def executable(self) -> str | None:

--- a/tests/test_uv_handling.py
+++ b/tests/test_uv_handling.py
@@ -239,7 +239,7 @@ def test_find_matching_listing_win(uv_installed_pythons):
         executable="C:\\Users\\ducks\\AppData\\Roaming\\uv\\python\\cpython-3.13.2-windows-x86_64-none\\python.exe",
         architecture="64bit",
         implementation="cpython",
-        managed_by="Astral UV",
+        managed_by="Astral uv",
         metadata={"freethreaded": False},
         shadowed=False,
     )
@@ -251,7 +251,7 @@ def test_find_matching_listing_win(uv_installed_pythons):
         executable="C:\\Users\\ducks\\AppData\\Roaming\\uv\\python\\pypy-3.10.19-windows-x86_64-none\\python.exe",
         architecture="64bit",
         implementation="pypy",
-        managed_by="Astral UV",
+        managed_by="Astral uv",
         metadata={"pypy_version": (7, 3, 19, "final", 0)},
         shadowed=False,
     )
@@ -302,7 +302,7 @@ def test_find_matching_listing_nonwin(uv_installed_pythons):
         executable="/home/david/.local/share/uv/python/cpython-3.13.2-linux-x86_64-gnu/bin/python",
         architecture="64bit",
         implementation="cpython",
-        managed_by="Astral UV",
+        managed_by="Astral uv",
         metadata={"freethreaded": False},
         shadowed=False,
     )
@@ -314,7 +314,7 @@ def test_find_matching_listing_nonwin(uv_installed_pythons):
         executable="/home/david/.local/share/uv/python/pypy-3.10.19-linux-x86_64-gnu/bin/python",
         architecture="64bit",
         implementation="pypy",
-        managed_by="Astral UV",
+        managed_by="Astral uv",
         metadata={"pypy_version": (7, 3, 18, "final", 0)},
         shadowed=False,
     )

--- a/tests/test_uv_handling.py
+++ b/tests/test_uv_handling.py
@@ -381,7 +381,6 @@ def test_install(uv_executable, uv_python_dir):
             ],
             capture_output=True,
             text=True,
-            check=True,
         )
 
         assert output == fake_out
@@ -432,7 +431,6 @@ def test_uninstall(uv_executable, uv_python_dir):
             ],
             capture_output=True,
             text=True,
-            check=True,
         )
 
         assert output == fake_out

--- a/tests/win32/test_pymanager_handling.py
+++ b/tests/win32/test_pymanager_handling.py
@@ -183,5 +183,4 @@ def test_install(pymanager_executable):
             ],
             capture_output=True,
             text=True,
-            check=True,
         )


### PR DESCRIPTION
The tui should no longer crash if an install fails and should display errors (for example, if there is no connection).

'Astral' has been changed to 'Astral uv'
